### PR TITLE
Add a periodic update process to handle (some) behaviors within this service

### DIFF
--- a/app.go
+++ b/app.go
@@ -3,12 +3,12 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"github.com/gorilla/mux"
-	"net/http"
-	"time"
 	"fmt"
+	"github.com/gorilla/mux"
 	"io"
 	"io/ioutil"
+	"net/http"
+	"time"
 )
 
 const hundredMiB = 104857600
@@ -275,10 +275,10 @@ func (a *AsyncTasksApp) CreateTaskRequest(writer http.ResponseWriter, r *http.Re
 
 func (a *AsyncTasksApp) AddStatusRequest(writer http.ResponseWriter, r *http.Request) {
 	var (
-		id string
-		ok bool
-	        rawstatus AsyncTaskStatus
-		v  = mux.Vars(r)
+		id        string
+		ok        bool
+		rawstatus AsyncTaskStatus
+		v         = mux.Vars(r)
 	)
 
 	if id, ok = v["id"]; !ok {
@@ -338,10 +338,10 @@ func (a *AsyncTasksApp) AddStatusRequest(writer http.ResponseWriter, r *http.Req
 
 func (a *AsyncTasksApp) AddBehaviorRequest(writer http.ResponseWriter, r *http.Request) {
 	var (
-		id string
-		ok bool
-	        rawbehavior AsyncTaskBehavior
-		v  = mux.Vars(r)
+		id          string
+		ok          bool
+		rawbehavior AsyncTaskBehavior
+		v           = mux.Vars(r)
 	)
 
 	if id, ok = v["id"]; !ok {

--- a/app.go
+++ b/app.go
@@ -138,10 +138,11 @@ func (a *AsyncTasksApp) GetByFilterRequest(writer http.ResponseWriter, r *http.R
 		v = r.URL.Query()
 
 		filters = database.TaskFilter{
-			IDs:       v["id"],
-			Types:     v["type"],
-			Statuses:  v["status"],
-			Usernames: v["username"],
+			IDs:           v["id"],
+			Types:         v["type"],
+			Statuses:      v["status"],
+			BehaviorTypes: v["behavior_types"],
+			Usernames:     v["username"],
 		}
 		start_date_since  = v["start_date_since"]
 		start_date_before = v["start_date_before"]
@@ -198,8 +199,6 @@ func (a *AsyncTasksApp) GetByFilterRequest(writer http.ResponseWriter, r *http.R
 	defer tx.Rollback()
 
 	tasks, err := tx.GetTasksByFilter(filters)
-
-	log.Info(tasks)
 
 	jsoned, err := json.Marshal(tasks)
 	if err != nil {

--- a/app.go
+++ b/app.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/cyverse-de/async-tasks/database"
+	"github.com/cyverse-de/async-tasks/model"
 	"github.com/gorilla/mux"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"time"
-	"github.com/cyverse-de/async-tasks/database"
-	"github.com/cyverse-de/async-tasks/model"
 )
 
 const hundredMiB = 104857600

--- a/app.go
+++ b/app.go
@@ -67,7 +67,7 @@ func (a *AsyncTasksApp) GetByIdRequest(writer http.ResponseWriter, r *http.Reque
 	}
 	defer tx.Rollback()
 
-	task, err := tx.GetTask(id)
+	task, err := tx.GetTask(id, false)
 	if err != nil {
 		errored(writer, err.Error())
 		return
@@ -112,7 +112,7 @@ func (a *AsyncTasksApp) DeleteByIdRequest(writer http.ResponseWriter, r *http.Re
 	}
 	defer tx.Rollback()
 
-	task, err := tx.GetTask(id)
+	task, err := tx.GetTask(id, true)
 	if err != nil {
 		errored(writer, err.Error())
 		return
@@ -296,7 +296,7 @@ func (a *AsyncTasksApp) AddStatusRequest(writer http.ResponseWriter, r *http.Req
 	}
 	defer tx.Rollback()
 
-	task, err := tx.GetTask(id)
+	task, err := tx.GetTask(id, true)
 	if err != nil {
 		errored(writer, err.Error())
 		return
@@ -359,7 +359,7 @@ func (a *AsyncTasksApp) AddBehaviorRequest(writer http.ResponseWriter, r *http.R
 	}
 	defer tx.Rollback()
 
-	task, err := tx.GetTask(id)
+	task, err := tx.GetTask(id, true)
 	if err != nil {
 		errored(writer, err.Error())
 		return

--- a/behaviors/statuschangetimeout/statuschangetimeout.go
+++ b/behaviors/statuschangetimeout/statuschangetimeout.go
@@ -5,8 +5,8 @@ import (
 	"github.com/cyverse-de/async-tasks/database"
 	"github.com/cyverse-de/async-tasks/model"
 	"github.com/mitchellh/mapstructure"
-	"github.com/sirupsen/logrus"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"time"
 )
 
@@ -14,6 +14,79 @@ type StatusChangeTimeoutData struct {
 	StartStatus string `mapstructure:"start_status"`
 	EndStatus   string `mapstructure:"end_status"`
 	Timeout     string `mapstructure:"timeout"`
+}
+
+func processSingleTask(ctx context.Context, log *logrus.Entry, db *database.DBConnection, ID string) error {
+	select {
+	// If the context is cancelled, don't bother
+	case <-ctx.Done():
+		return nil
+	default:
+	}
+
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	fullTask, err := tx.GetTask(ID)
+	if err != nil {
+		err = errors.Wrap(err, "failed getting task")
+		log.Error(err)
+		return err
+	}
+
+	var taskData StatusChangeTimeoutData
+	for _, behavior := range fullTask.Behaviors {
+		// XXX: currently only does the first statuschangetimeout, should do all of them (possibly repeatedly, until none does anything)
+		if behavior.BehaviorType == "statuschangetimeout" {
+			err := mapstructure.Decode(behavior.Data, &taskData)
+			if err != nil {
+				// don't die here, let it try other behaviors
+				log.Error(errors.Wrap(err, "failed decoding behavior"))
+			}
+			break
+		}
+	}
+
+	timeout, err := time.ParseDuration(taskData.Timeout)
+	if err != nil {
+		err = errors.Wrap(err, "failed parsing timeout duration")
+		log.Error(err)
+		return err
+	}
+
+	var comparisonTimestamp time.Time
+	var comparisonStatus string
+	if len(fullTask.Statuses) == 0 {
+		comparisonTimestamp = *fullTask.StartDate
+	} else {
+		for _, status := range fullTask.Statuses {
+			if status.CreatedDate.After(comparisonTimestamp) {
+				comparisonTimestamp = status.CreatedDate
+				comparisonStatus = status.Status
+			}
+		}
+	}
+
+	log.Info(comparisonTimestamp)
+
+	if comparisonTimestamp.Add(timeout).Before(time.Now()) && comparisonStatus == taskData.StartStatus {
+		newstatus := model.AsyncTaskStatus{Status: taskData.EndStatus}
+		err = tx.InsertTaskStatus(newstatus, ID)
+		if err != nil {
+			err = errors.Wrap(err, "failed inserting task status")
+			log.Error(err)
+			return err
+		}
+		tx.Commit()
+		log.Infof("updated task given time %s and status %s, timeout/start %s/%s", comparisonTimestamp, comparisonStatus, timeout, taskData.StartStatus)
+	} else {
+		log.Infof("would NOT update given time %s and status %s, timeout/start %s/%s", comparisonTimestamp, comparisonStatus, timeout, taskData.StartStatus)
+	}
+
+	return nil
 }
 
 func Processor(ctx context.Context, log *logrus.Entry, _ time.Time, db *database.DBConnection) error {
@@ -32,12 +105,11 @@ func Processor(ctx context.Context, log *logrus.Entry, _ time.Time, db *database
 		return err
 	}
 
+	tx.Rollback()
+
 	log.Infof("Tasks with statuschangetimeout behavior: %d", len(tasks))
 
 	for _, task := range tasks {
-		// rollback here before creating a new tx below, whatever tx is set to now
-		tx.Rollback()
-
 		select {
 		// If the context is cancelled, don't bother
 		case <-ctx.Done():
@@ -45,65 +117,11 @@ func Processor(ctx context.Context, log *logrus.Entry, _ time.Time, db *database
 		default:
 		}
 
-		tx, err = db.BeginTx(ctx, nil)
+		err = processSingleTask(ctx, log, db, task.ID)
 		if err != nil {
-			return err
-		}
-
-		fullTask, err := tx.GetTask(task.ID)
-		if err != nil {
-			log.Error(errors.Wrap(err, "failed getting task"))
-			continue
-		}
-
-		var taskData StatusChangeTimeoutData
-		for _, behavior := range fullTask.Behaviors {
-			if behavior.BehaviorType == "statuschangetimeout" {
-				err := mapstructure.Decode(behavior.Data, &taskData)
-				if err != nil {
-					log.Error(errors.Wrap(err, "failed decoding behavior"))
-				}
-				break
-			}
-		}
-
-		timeout, err := time.ParseDuration(taskData.Timeout)
-		if err != nil {
-			log.Error(errors.Wrap(err, "failed parsing timeout duration"))
-			continue
-		}
-
-		var comparisonTimestamp time.Time
-		var comparisonStatus string
-		if len(fullTask.Statuses) == 0 {
-			comparisonTimestamp = *fullTask.StartDate
-		} else {
-			for _, status := range fullTask.Statuses {
-				if status.CreatedDate.After(comparisonTimestamp) {
-					comparisonTimestamp = status.CreatedDate
-					comparisonStatus = status.Status
-				}
-			}
-		}
-
-		log.Info(comparisonTimestamp)
-
-		if comparisonTimestamp.Add(timeout).Before(time.Now()) && comparisonStatus == taskData.StartStatus {
-			newstatus := model.AsyncTaskStatus{Status: taskData.EndStatus}
-			err = tx.InsertTaskStatus(newstatus, task.ID)
-			if err != nil {
-				log.Error(errors.Wrap(err, "failed inserting task status"))
-				continue
-			}
-			tx.Commit()
-			log.Infof("updated task given time %s and status %s, timeout/start %s/%s", comparisonTimestamp, comparisonStatus, timeout, taskData.StartStatus)
-		} else {
-			log.Infof("would NOT update given time %s and status %s, timeout/start %s/%s", comparisonTimestamp, comparisonStatus, timeout, taskData.StartStatus)
+			log.Error(errors.Wrap(err, "failed processing a task"))
 		}
 	}
-
-	// just in case
-	tx.Rollback()
 
 	return nil
 }

--- a/behaviors/statuschangetimeout/statuschangetimeout.go
+++ b/behaviors/statuschangetimeout/statuschangetimeout.go
@@ -2,9 +2,9 @@ package statuschangetimeout
 
 import (
 	"context"
-	"time"
 	"github.com/cyverse-de/async-tasks/database"
 	"github.com/sirupsen/logrus"
+	"time"
 )
 
 func Processor(_ context.Context, log *logrus.Entry, _ time.Time, db *database.DBConnection) error {

--- a/behaviors/statuschangetimeout/statuschangetimeout.go
+++ b/behaviors/statuschangetimeout/statuschangetimeout.go
@@ -30,7 +30,7 @@ func processSingleTask(ctx context.Context, log *logrus.Entry, db *database.DBCo
 	}
 	defer tx.Rollback()
 
-	fullTask, err := tx.GetTask(ID)
+	fullTask, err := tx.GetTask(ID, true)
 	if err != nil {
 		err = errors.Wrap(err, "failed getting task")
 		log.Error(err)

--- a/behaviors/statuschangetimeout/statuschangetimeout.go
+++ b/behaviors/statuschangetimeout/statuschangetimeout.go
@@ -1,0 +1,17 @@
+package statuschangetimeout
+
+import (
+	"context"
+	"time"
+	"github.com/cyverse-de/async-tasks/database"
+	"github.com/sirupsen/logrus"
+)
+
+func Processor(_ context.Context, log *logrus.Entry, _ time.Time, db *database.DBConnection) error {
+	c, err := db.GetCount()
+	if err != nil {
+		return err
+	}
+	log.Infof("There are %d tasks in the DB", c)
+	return nil
+}

--- a/database.go
+++ b/database.go
@@ -7,8 +7,8 @@ import (
 	"github.com/cyverse-de/dbutil"
 	"github.com/lib/pq"
 
-	"fmt"
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 

--- a/database/database.go
+++ b/database/database.go
@@ -4,28 +4,28 @@ import (
 	"context"
 
 	"database/sql"
+	"github.com/cyverse-de/async-tasks/model"
 	"github.com/cyverse-de/dbutil"
 	"github.com/lib/pq"
-	"github.com/cyverse-de/async-tasks/model"
 
 	"errors"
 	"fmt"
+	"github.com/sirupsen/logrus"
 	"strings"
 	"time"
-        "github.com/sirupsen/logrus"
 
 	"encoding/json"
 )
 
 // DBConnection wraps a sql.DB
 type DBConnection struct {
-	db *sql.DB
+	db  *sql.DB
 	log *logrus.Entry
 }
 
 // DBTx wraps a sql.Tx for this DB
 type DBTx struct {
-	tx *sql.Tx
+	tx  *sql.Tx
 	log *logrus.Entry
 }
 
@@ -62,7 +62,7 @@ func (d *DBConnection) Close() error {
 // GetCount gets a count of async tasks in the DB
 func (d *DBConnection) GetCount() (int64, error) {
 	row := d.db.QueryRow("SELECT COUNT(*) FROM async_tasks")
-	var res struct { count int64 }
+	var res struct{ count int64 }
 	err := row.Scan(&res.count)
 	if err != nil {
 		return 0, err

--- a/database/database.go
+++ b/database/database.go
@@ -162,6 +162,24 @@ func (t *DBTx) DeleteTask(id string) error {
 	return nil
 }
 
+// CompleteTask marks a task as ended by setting the end date to now()
+func (t *DBTx) CompleteTask(id string) error {
+	query := `UPDATE async_tasks SET end_date = now() WHERE id = $1`
+
+	rows, err := t.tx.Query(query, id)
+	if err != nil {
+		return err
+	}
+	if err = rows.Err(); err != nil {
+		return err
+	}
+	if err = rows.Close(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // GetTask fetches a task from the database by ID, including behaviors and statuses
 func (t *DBTx) GetTask(id string, forUpdate bool) (*model.AsyncTask, error) {
 	task, err := t.GetBaseTask(id, forUpdate)

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/magiconair/properties v1.8.1
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/pelletier/go-toml v1.4.0
+	github.com/pkg/errors v0.8.0
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/afero v1.2.2
 	github.com/spf13/cast v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -68,6 +68,7 @@ github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.4.0 h1:u3Z1r+oOXJIkxqw34zVhyPgjBsm6X2wn21NWs/HfSeg=
 github.com/pelletier/go-toml v1.4.0/go.mod h1:PN7xzY2wHTK0K9p34ErDQMlFxa51Fk0OUruD3k1mMwo=
+github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,7 @@ github.com/cyverse-de/configurate v0.0.0-20190318152107-8f767cb828d9 h1:GXDamvpo
 github.com/cyverse-de/configurate v0.0.0-20190318152107-8f767cb828d9/go.mod h1:QMZ4G8bX5f0vKiH9+/2JqV687mN1byJ18tjZwIJIagI=
 github.com/cyverse-de/dbutil v0.0.0-20160615220802-d6ccc51d67cd h1:cIUGNefDp8/c92Dk8fUbCUcnXGyt4gM71mQ5tuXfRLo=
 github.com/cyverse-de/dbutil v0.0.0-20160615220802-d6ccc51d67cd/go.mod h1:ExgEsAIPqEEtubF/XyUlj8+4ReFsbyT9QChN6EsorN8=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
@@ -68,6 +69,7 @@ github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/9
 github.com/pelletier/go-toml v1.4.0 h1:u3Z1r+oOXJIkxqw34zVhyPgjBsm6X2wn21NWs/HfSeg=
 github.com/pelletier/go-toml v1.4.0/go.mod h1:PN7xzY2wHTK0K9p34ErDQMlFxa51Fk0OUruD3k1mMwo=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDft0ttaMvbicHlPoso=
@@ -97,6 +99,7 @@ github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnIn
 github.com/spf13/viper v1.4.0 h1:yXHLWeravcrgGyFSyCgdYpXQ9dR9c/WED3pg1RhxqEU=
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=

--- a/main.go
+++ b/main.go
@@ -74,6 +74,7 @@ func main() {
 	log.Infof("There are %d async tasks in the database", res.count)
 
 	// Make periodic updater
+	updater := NewAsyncTasksUpdater(db)
 	ticker := time.NewTicker(30 * time.Second) // twice a minute means minutely updates behave basically decently, if we need faster we can change this
 	defer ticker.Stop()
 
@@ -81,6 +82,10 @@ func main() {
 		for {
 			t := <-ticker.C
 			log.Infof("Got periodic timer tick: %s", t)
+			err := updater.Do(t)
+			if err != nil {
+				log.Error(err)
+			}
 		}
 	}()
 

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 	"time"
+	"context"
 
 	"net/http"
 	"github.com/gorilla/mux"
@@ -82,7 +83,9 @@ func main() {
 		for {
 			t := <-ticker.C
 			log.Infof("Got periodic timer tick: %s", t)
-			err := updater.Do(t)
+
+			ctx := context.TODO()
+			err := updater.Do(ctx, t)
 			if err != nil {
 				log.Error(err)
 			}

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"strings"
+	"time"
 
 	"net/http"
 	"github.com/gorilla/mux"
@@ -72,6 +73,18 @@ func main() {
 	row.Scan(&res)
 	log.Infof("There are %d async tasks in the database", res.count)
 
+	// Make periodic updater
+	ticker := time.NewTicker(30 * time.Second) // twice a minute means minutely updates behave basically decently, if we need faster we can change this
+	defer ticker.Stop()
+
+	go func() {
+		for {
+			t := <-ticker.C
+			log.Infof("Got periodic timer tick: %s", t)
+		}
+	}()
+
+	// Make HTTP listeners
 	router := makeRouter()
 
 	app := NewAsyncTasksApp(db, router)

--- a/main.go
+++ b/main.go
@@ -91,7 +91,7 @@ func main() {
 			t := <-ticker.C
 			log.Infof("Got periodic timer tick: %s", t)
 
-			ctx, cancel := context.WithTimeout(context.Background(), 10 * time.Minute) // long timeout we can use to clear out totally stuck jobs
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute) // long timeout we can use to clear out totally stuck jobs
 			defer cancel()
 
 			err := updater.DoPeriodicUpdate(ctx, t, db)

--- a/main.go
+++ b/main.go
@@ -91,7 +91,7 @@ func main() {
 			t := <-ticker.C
 			log.Infof("Got periodic timer tick: %s", t)
 
-			ctx, cancel := context.WithCancel(context.Background())
+			ctx, cancel := context.WithTimeout(context.Background(), 10 * time.Minute) // long timeout we can use to clear out totally stuck jobs
 			defer cancel()
 
 			err := updater.DoPeriodicUpdate(ctx, t, db)

--- a/main.go
+++ b/main.go
@@ -84,8 +84,10 @@ func main() {
 			t := <-ticker.C
 			log.Infof("Got periodic timer tick: %s", t)
 
-			ctx := context.TODO()
-			err := updater.Do(ctx, t)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			err := updater.DoPeriodicUpdate(ctx, t)
 			if err != nil {
 				log.Error(err)
 			}

--- a/main.go
+++ b/main.go
@@ -1,15 +1,15 @@
 package main
 
 import (
+	"context"
 	_ "expvar"
 	"flag"
 	"fmt"
 	"strings"
 	"time"
-	"context"
 
-	"net/http"
 	"github.com/gorilla/mux"
+	"net/http"
 
 	"github.com/cyverse-de/configurate"
 	"github.com/sirupsen/logrus"
@@ -17,9 +17,9 @@ import (
 )
 
 var log = logrus.WithFields(logrus.Fields{
-        "service": "async-tasks",
-        "art-id":  "async-tasks",
-        "group":   "org.cyverse",
+	"service": "async-tasks",
+	"art-id":  "async-tasks",
+	"group":   "org.cyverse",
 })
 
 func init() {
@@ -37,18 +37,18 @@ func makeRouter() *mux.Router {
 }
 
 func fixAddr(addr string) string {
-        if !strings.HasPrefix(addr, ":") {
-                return fmt.Sprintf(":%s", addr)
-        }
-        return addr
+	if !strings.HasPrefix(addr, ":") {
+		return fmt.Sprintf(":%s", addr)
+	}
+	return addr
 }
 
 func main() {
 	var (
 		cfgPath = flag.String("config", "/etc/iplant/de/async-tasks.yml", "The path to the config file")
 		port    = flag.String("port", "60000", "The port number to listen on")
-		err error
-		cfg *viper.Viper
+		err     error
+		cfg     *viper.Viper
 	)
 
 	flag.Parse()
@@ -69,8 +69,8 @@ func main() {
 	}
 	defer db.db.Close()
 
-	row := db.db.QueryRow("SELECT COUNT(*) FROM async_tasks");
-	var res struct{count int}
+	row := db.db.QueryRow("SELECT COUNT(*) FROM async_tasks")
+	var res struct{ count int }
 	row.Scan(&res)
 	log.Infof("There are %d async tasks in the database", res.count)
 

--- a/main.go
+++ b/main.go
@@ -13,6 +13,8 @@ import (
 
 	"github.com/cyverse-de/async-tasks/database"
 
+	"github.com/cyverse-de/async-tasks/behaviors/statuschangetimeout"
+
 	"github.com/cyverse-de/configurate"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
@@ -79,6 +81,8 @@ func main() {
 
 	// Make periodic updater
 	updater := NewAsyncTasksUpdater(db)
+	updater.AddBehavior("statuschangetimeout", statuschangetimeout.Processor)
+
 	ticker := time.NewTicker(30 * time.Second) // twice a minute means minutely updates behave basically decently, if we need faster we can change this
 	defer ticker.Stop()
 

--- a/model/model.go
+++ b/model/model.go
@@ -1,4 +1,4 @@
-package main
+package model
 
 import (
 	"database/sql"

--- a/updater.go
+++ b/updater.go
@@ -2,13 +2,13 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"github.com/cyverse-de/async-tasks/database"
 	"github.com/cyverse-de/async-tasks/model"
-	"github.com/sirupsen/logrus"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"sync"
 	"time"
-	"fmt"
 )
 
 type BehaviorProcessor func(ctx context.Context, log *logrus.Entry, tickerTime time.Time, db *database.DBConnection) error
@@ -34,7 +34,7 @@ func createBehaviorProcessorTask(ctx context.Context, behaviorType string, db *d
 	if err != nil {
 		return "", err
 	}
-	defer tx.Rollback();
+	defer tx.Rollback()
 
 	task := model.AsyncTask{Type: fmt.Sprintf("behaviorprocessor-%s", behaviorType)}
 
@@ -52,16 +52,16 @@ func createBehaviorProcessorTask(ctx context.Context, behaviorType string, db *d
 }
 
 func checkOldest(ctx context.Context, behaviorType string, db *database.DBConnection, taskID string) error {
-        tx, err := db.BeginTx(ctx, nil)
+	tx, err := db.BeginTx(ctx, nil)
 	if err != nil {
 		return err
 	}
-	defer tx.Rollback();
+	defer tx.Rollback()
 
 	filter := database.TaskFilter{
-		Types: []string{fmt.Sprintf("behaviorprocessor-%s", behaviorType)},
+		Types:          []string{fmt.Sprintf("behaviorprocessor-%s", behaviorType)},
 		StartDateSince: []time.Time{time.Now().Add(time.Minute * -12)}, // the timeout is 10 minutes, but add some padding
-		EndDateSince: []time.Time{time.Now().AddDate(1, 0, 0)}, // arbitrary point in the future a ways
+		EndDateSince:   []time.Time{time.Now().AddDate(1, 0, 0)},       // arbitrary point in the future a ways
 		IncludeNullEnd: true,
 	}
 
@@ -98,11 +98,11 @@ func checkAlone(ctx context.Context, behaviorType string, db *database.DBConnect
 }
 
 func finishTask(ctx context.Context, taskID string, db *database.DBConnection) error {
-        tx, err := db.BeginTx(ctx, nil)
+	tx, err := db.BeginTx(ctx, nil)
 	if err != nil {
 		return err
 	}
-	defer tx.Rollback();
+	defer tx.Rollback()
 
 	err = tx.CompleteTask(taskID)
 	if err != nil {

--- a/updater.go
+++ b/updater.go
@@ -1,22 +1,52 @@
 package main
 
 import (
+	"context"
 	"time"
+	"sync"
 )
+
+type BehaviorProcessor func(ctx context.Context, tickerTime time.Time) error
 
 type AsyncTasksUpdater struct {
 	db *DBConnection
+	behaviorProcessors map[string]BehaviorProcessor
 }
 
 func NewAsyncTasksUpdater(db *DBConnection) *AsyncTasksUpdater {
+	processors := make(map[string]BehaviorProcessor)
+
 	updater := &AsyncTasksUpdater{
 		db: db,
+		behaviorProcessors: processors,
 	}
 
 	return updater
 }
 
-func (u *AsyncTasksUpdater) Do(tickerTime time.Time) error {
+func (u *AsyncTasksUpdater) Do(ctx context.Context, tickerTime time.Time) error {
 	log.Infof("Running update with time %s", tickerTime)
+
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	for behaviorType, processor := range u.behaviorProcessors {
+		wg.Add(1)
+		go func(ctx context.Context, behaviorType string, tickerTime time.Time, wg *sync.WaitGroup) {
+			defer wg.Done()
+			log.Infof("Processing behavior type %s for time %s", behaviorType, tickerTime)
+			err := processor(ctx, tickerTime)
+			if err != nil {
+				log.Error(err)
+			}
+		}(ctx, behaviorType, tickerTime, &wg)
+	}
+	wg.Done()
+	wg.Wait()
+	log.Infof("Done running update with time %s", tickerTime)
 	return nil
+}
+
+func (u *AsyncTasksUpdater) AddBehavior(behaviorType string, processor BehaviorProcessor) {
+	u.behaviorProcessors[behaviorType] = processor
 }

--- a/updater.go
+++ b/updater.go
@@ -90,7 +90,7 @@ func checkAlone(ctx context.Context, behaviorType string, db *database.DBConnect
 	// make a task
 	id, err := createBehaviorProcessorTask(ctx, behaviorType, db)
 	if err != nil {
-		return "", err
+		return id, err
 	}
 	// check that we're the right task to continue
 	return id, checkOldest(ctx, behaviorType, db, id)
@@ -126,7 +126,9 @@ func (u *AsyncTasksUpdater) DoPeriodicUpdate(ctx context.Context, tickerTime tim
 			})
 			// check if alone
 			taskID, err := checkAlone(ctx, behaviorType, db)
-			defer finishTask(ctx, taskID, db)
+			if taskID != "" {
+				defer finishTask(ctx, taskID, db)
+			}
 			if err != nil {
 				processorLog.Error(errors.Wrap(err, "We are not the oldest process for this behavior type"))
 				return

--- a/updater.go
+++ b/updater.go
@@ -5,9 +5,10 @@ import (
 	"sync"
 	"time"
 	"github.com/cyverse-de/async-tasks/database"
+	"github.com/sirupsen/logrus"
 )
 
-type BehaviorProcessor func(ctx context.Context, tickerTime time.Time, db *database.DBConnection) error
+type BehaviorProcessor func(ctx context.Context, log *logrus.Entry, tickerTime time.Time, db *database.DBConnection) error
 
 type AsyncTasksUpdater struct {
 	db                 *database.DBConnection
@@ -36,7 +37,7 @@ func (u *AsyncTasksUpdater) DoPeriodicUpdate(ctx context.Context, tickerTime tim
 		go func(ctx context.Context, behaviorType string, processor BehaviorProcessor, tickerTime time.Time, db *database.DBConnection, wg *sync.WaitGroup) {
 			defer wg.Done()
 			log.Infof("Processing behavior type %s for time %s", behaviorType, tickerTime)
-			err := processor(ctx, tickerTime, db)
+			err := processor(ctx, log, tickerTime, db)
 			if err != nil {
 				log.Error(err)
 			}

--- a/updater.go
+++ b/updater.go
@@ -29,7 +29,7 @@ func (u *AsyncTasksUpdater) DoPeriodicUpdate(ctx context.Context, tickerTime tim
 
 	var wg sync.WaitGroup
 
-	wg.Add(1)
+	wg.Add(1) // add this so there's always at least one thing in the work group
 	for behaviorType, processor := range u.behaviorProcessors {
 		wg.Add(1)
 		go func(ctx context.Context, behaviorType string, processor BehaviorProcessor, tickerTime time.Time, wg *sync.WaitGroup) {
@@ -39,9 +39,10 @@ func (u *AsyncTasksUpdater) DoPeriodicUpdate(ctx context.Context, tickerTime tim
 			if err != nil {
 				log.Error(err)
 			}
+			log.Infof("Done processing behavior type %s for time %s", behaviorType, tickerTime)
 		}(ctx, behaviorType, processor, tickerTime, &wg)
 	}
-	wg.Done()
+	wg.Done() // finish our dummy entry in the work group
 	wg.Wait()
 	log.Infof("Done running update with time %s", tickerTime)
 	return nil

--- a/updater.go
+++ b/updater.go
@@ -37,7 +37,10 @@ func (u *AsyncTasksUpdater) DoPeriodicUpdate(ctx context.Context, tickerTime tim
 		go func(ctx context.Context, behaviorType string, processor BehaviorProcessor, tickerTime time.Time, db *database.DBConnection, wg *sync.WaitGroup) {
 			defer wg.Done()
 			log.Infof("Processing behavior type %s for time %s", behaviorType, tickerTime)
-			err := processor(ctx, log, tickerTime, db)
+			processorLog := log.WithFields(logrus.Fields{
+				"behavior_type": behaviorType,
+			})
+			err := processor(ctx, processorLog, tickerTime, db)
 			if err != nil {
 				log.Error(err)
 			}

--- a/updater.go
+++ b/updater.go
@@ -60,6 +60,7 @@ func checkOldest(ctx context.Context, behaviorType string, db *database.DBConnec
 
 	filter := database.TaskFilter{
 		Types: []string{fmt.Sprintf("behaviorprocessor-%s", behaviorType)},
+		StartDateSince: []time.Time{time.Now().Add(time.Minute * -12)}, // the timeout is 10 minutes, but add some padding
 		EndDateSince: []time.Time{time.Now().AddDate(1, 0, 0)}, // arbitrary point in the future a ways
 		IncludeNullEnd: true,
 	}

--- a/updater.go
+++ b/updater.go
@@ -2,14 +2,14 @@ package main
 
 import (
 	"context"
-	"time"
 	"sync"
+	"time"
 )
 
 type BehaviorProcessor func(ctx context.Context, tickerTime time.Time) error
 
 type AsyncTasksUpdater struct {
-	db *DBConnection
+	db                 *DBConnection
 	behaviorProcessors map[string]BehaviorProcessor
 }
 
@@ -17,7 +17,7 @@ func NewAsyncTasksUpdater(db *DBConnection) *AsyncTasksUpdater {
 	processors := make(map[string]BehaviorProcessor)
 
 	updater := &AsyncTasksUpdater{
-		db: db,
+		db:                 db,
 		behaviorProcessors: processors,
 	}
 

--- a/updater.go
+++ b/updater.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"time"
+)
+
+type AsyncTasksUpdater struct {
+	db *DBConnection
+}
+
+func NewAsyncTasksUpdater(db *DBConnection) *AsyncTasksUpdater {
+	updater := &AsyncTasksUpdater{
+		db: db,
+	}
+
+	return updater
+}
+
+func (u *AsyncTasksUpdater) Do(tickerTime time.Time) error {
+	log.Infof("Running update with time %s", tickerTime)
+	return nil
+}

--- a/updater.go
+++ b/updater.go
@@ -24,7 +24,7 @@ func NewAsyncTasksUpdater(db *DBConnection) *AsyncTasksUpdater {
 	return updater
 }
 
-func (u *AsyncTasksUpdater) Do(ctx context.Context, tickerTime time.Time) error {
+func (u *AsyncTasksUpdater) DoPeriodicUpdate(ctx context.Context, tickerTime time.Time) error {
 	log.Infof("Running update with time %s", tickerTime)
 
 	var wg sync.WaitGroup
@@ -32,14 +32,14 @@ func (u *AsyncTasksUpdater) Do(ctx context.Context, tickerTime time.Time) error 
 	wg.Add(1)
 	for behaviorType, processor := range u.behaviorProcessors {
 		wg.Add(1)
-		go func(ctx context.Context, behaviorType string, tickerTime time.Time, wg *sync.WaitGroup) {
+		go func(ctx context.Context, behaviorType string, processor BehaviorProcessor, tickerTime time.Time, wg *sync.WaitGroup) {
 			defer wg.Done()
 			log.Infof("Processing behavior type %s for time %s", behaviorType, tickerTime)
 			err := processor(ctx, tickerTime)
 			if err != nil {
 				log.Error(err)
 			}
-		}(ctx, behaviorType, tickerTime, &wg)
+		}(ctx, behaviorType, processor, tickerTime, &wg)
 	}
 	wg.Done()
 	wg.Wait()

--- a/updater.go
+++ b/updater.go
@@ -2,10 +2,10 @@ package main
 
 import (
 	"context"
-	"sync"
-	"time"
 	"github.com/cyverse-de/async-tasks/database"
 	"github.com/sirupsen/logrus"
+	"sync"
+	"time"
 )
 
 type BehaviorProcessor func(ctx context.Context, log *logrus.Entry, tickerTime time.Time, db *database.DBConnection) error

--- a/updater.go
+++ b/updater.go
@@ -3,9 +3,12 @@ package main
 import (
 	"context"
 	"github.com/cyverse-de/async-tasks/database"
+	"github.com/cyverse-de/async-tasks/model"
 	"github.com/sirupsen/logrus"
+	"github.com/pkg/errors"
 	"sync"
 	"time"
+	"fmt"
 )
 
 type BehaviorProcessor func(ctx context.Context, log *logrus.Entry, tickerTime time.Time, db *database.DBConnection) error
@@ -26,6 +29,88 @@ func NewAsyncTasksUpdater(db *database.DBConnection) *AsyncTasksUpdater {
 	return updater
 }
 
+func createBehaviorProcessorTask(ctx context.Context, behaviorType string, db *database.DBConnection) (string, error) {
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return "", err
+	}
+	defer tx.Rollback();
+
+	task := model.AsyncTask{Type: fmt.Sprintf("behaviorprocessor-%s", behaviorType)}
+
+	id, err := tx.InsertTask(task)
+	if err != nil {
+		return "", err
+	}
+
+	err = tx.Commit()
+	if err != nil {
+		return "", err
+	}
+
+	return id, nil
+}
+
+func checkOldest(ctx context.Context, behaviorType string, db *database.DBConnection, taskID string) error {
+        tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback();
+
+	filter := database.TaskFilter{
+		Types: []string{fmt.Sprintf("behaviorprocessor-%s", behaviorType)},
+		EndDateSince: []time.Time{time.Now().AddDate(1, 0, 0)}, // arbitrary point in the future a ways
+		IncludeNullEnd: true,
+	}
+
+	tasks, err := tx.GetTasksByFilter(filter)
+	if err != nil {
+		return err
+	}
+
+	var t = time.Now()
+	var oldestTime = &t
+	var isOldest = true
+	for _, task := range tasks {
+		if oldestTime == nil || oldestTime.IsZero() || task.StartDate.Before(*oldestTime) {
+			oldestTime = task.StartDate
+			isOldest = (task.ID == taskID)
+		}
+	}
+
+	if !isOldest {
+		return errors.New("The provided ID is not the oldest task of its type")
+	}
+
+	return nil
+}
+
+func checkAlone(ctx context.Context, behaviorType string, db *database.DBConnection) (string, error) {
+	// make a task
+	id, err := createBehaviorProcessorTask(ctx, behaviorType, db)
+	if err != nil {
+		return "", err
+	}
+	// check that we're the right task to continue
+	return id, checkOldest(ctx, behaviorType, db, id)
+}
+
+func finishTask(ctx context.Context, taskID string, db *database.DBConnection) error {
+        tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback();
+
+	err = tx.CompleteTask(taskID)
+	if err != nil {
+		return err
+	}
+
+	return tx.Commit()
+}
+
 func (u *AsyncTasksUpdater) DoPeriodicUpdate(ctx context.Context, tickerTime time.Time, db *database.DBConnection) error {
 	log.Infof("Running update with time %s", tickerTime)
 
@@ -36,15 +121,24 @@ func (u *AsyncTasksUpdater) DoPeriodicUpdate(ctx context.Context, tickerTime tim
 		wg.Add(1)
 		go func(ctx context.Context, behaviorType string, processor BehaviorProcessor, tickerTime time.Time, db *database.DBConnection, wg *sync.WaitGroup) {
 			defer wg.Done()
-			log.Infof("Processing behavior type %s for time %s", behaviorType, tickerTime)
 			processorLog := log.WithFields(logrus.Fields{
 				"behavior_type": behaviorType,
 			})
-			err := processor(ctx, processorLog, tickerTime, db)
+			// check if alone
+			taskID, err := checkAlone(ctx, behaviorType, db)
+			defer finishTask(ctx, taskID, db)
 			if err != nil {
-				log.Error(err)
+				processorLog.Error(errors.Wrap(err, "We are not the oldest process for this behavior type"))
+				return
 			}
-			log.Infof("Done processing behavior type %s for time %s", behaviorType, tickerTime)
+
+			processorLog.Infof("Processing behavior type %s for time %s (task ID %s)", behaviorType, tickerTime, taskID)
+			err = processor(ctx, processorLog, tickerTime, db)
+			if err != nil {
+				processorLog.Error(err)
+			}
+			processorLog.Infof("Done processing behavior type %s for time %s", behaviorType, tickerTime)
+			// release "lock"
 		}(ctx, behaviorType, processor, tickerTime, db, &wg)
 	}
 	wg.Done() // finish our dummy entry in the work group


### PR DESCRIPTION
This PR allows clients to create tasks with behaviors of type "statuschangetimeout", which includes a timeout, a starting status to check for, and an ending status, where the periodic checking will find tasks with the starting status with a date further in the past than the timeout, and add a status of the new type to them. This can be used to mark "possibly stalled" tasks, or similar.

- [x] add a goroutine and ticker to handle these kinds of periodic-checking behaviors
- [x] create a handler for the statuschangetimeout behavior
- [x] finalize the API for behavior processors (for now: timestamp, ctx, database)
- [x] allow marking tasks completed via the add status API
- [x] allow marking tasks completed via the statuschangetimeout behavior
- [x] handle multiple instances of async-tasks running the same behavior processors (by having the behavior processors create async tasks themselves -- when started, create the task, then in the processor, verify that our task is either the oldest or newest open task of that type, ending/closing immediately if not, to hopefully ensure one processor at a time)

One thing which is not done, but which is worked around, is that if an async-tasks instance dies, the updates will stop for roughly 10 minutes due to a timeout/filter put in place in the concurrency-prevention code, but then will resume. However, the old task will still stay open. Most likely we should ensure the service cleans up its own tasks eventually, but that's not needed to get this moving forward probably.