### PR TITLE
Rework SQL generation to use squirrel

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -358,9 +358,6 @@ func (t *DBTx) GetTasksByFilter(filters TaskFilter, order string) ([]model.Async
 		query = query.Join("(" + nestedJoinSelect + ") AS behaviors ON (behaviors.async_task_id = async_tasks.id)").Where(`behavior_types && ?`, pq.Array(filters.BehaviorTypes))
 	}
 
-	s, _, _ := query.ToSql()
-	t.log.Info(s)
-
 	rows, err := query.RunWith(t.tx).Query()
 	if err != nil {
 		return nil, err

--- a/database/database.go
+++ b/database/database.go
@@ -91,8 +91,8 @@ var psql squirrel.StatementBuilderType = squirrel.StatementBuilder.PlaceholderFo
 
 var baseTaskSelect squirrel.SelectBuilder = psql.Select(
 	"id", "type", "username", "data",
-	"start_date at time zone (select current_setting('TIMEZONE') AS start_date)",
-	"end_date at time zone (select current_setting('TIMEZONE')) AS end_date",
+	"start_date at time zone (select current_setting('TIMEZONE'))",
+	"end_date at time zone (select current_setting('TIMEZONE'))",
 ).From("async_tasks")
 
 // GetBaseTask fetches a task from the database by ID (sans behaviors/statuses)
@@ -249,7 +249,7 @@ func (t *DBTx) GetTaskBehaviors(id string, forUpdate bool) ([]model.AsyncTaskBeh
 }
 
 var baseTaskStatusSelect squirrel.SelectBuilder = psql.Select(
-	"status", "detail", "created_date at time zone (select current_setting('TIMEZONE')) AS created_date",
+	"status", "detail", "created_date at time zone (select current_setting('TIMEZONE'))",
 ).From("async_task_status")
 
 // GetTaskStatuses fetches a tasks's list of statuses from the DB by ID, ordered by creation date

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/cyverse-de/async-tasks
 go 1.13
 
 require (
+	github.com/Masterminds/squirrel v1.4.0
 	github.com/cyverse-de/configurate v0.0.0-20190318152107-8f767cb828d9
 	github.com/cyverse-de/dbutil v0.0.0-20160615220802-d6ccc51d67cd
 	github.com/fsnotify/fsnotify v1.4.7

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/Masterminds/squirrel v1.4.0 h1:he5i/EXixZxrBUWcxzDYMiju9WZ3ld/l7QBNuo/eN3w=
+github.com/Masterminds/squirrel v1.4.0/go.mod h1:yaPeOnPG5ZRwL9oKdTsO/prlkPbXWZlRVMQ/gGlzIuA=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -55,6 +57,10 @@ github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFB
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 h1:SOEGU9fKiNWd/HOJuq6+3iTQz8KNCLtVX6idSoTLdUw=
+github.com/lann/builder v0.0.0-20180802200727-47ae307949d0/go.mod h1:dXGbAdH5GtBTC4WfIxhKZfyBF/HBFgRZSWwZ9g/He9o=
+github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 h1:P6pPBnrTSX3DEVR4fDembhRWSsG5rVo6hYhAB/ADZrk=
+github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0/go.mod h1:vmVJ0l/dxyfGW6FmdpVm2joNMFikkuWg0EoCKLGUMNw=
 github.com/lib/pq v1.2.0 h1:LXpIM/LZ5xGFhOpXAQUIMM1HdyqzVYM13zNdjCEEcA0=
 github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=


### PR DESCRIPTION
As I originally wrote it, async-tasks is doing a... well, 3N+1 problem thing in the behavior processor, wherein there's one query to get a bunch of tasks, then for each one a query to get the task again, plus two more to get statuses and behaviors. We probably shouldn't have to fetch the base tasks twice, and we certainly shouldn't be doing three selects inside a loop, but the SQL generation logic was pretty gnarly. This PR rewrites it to use Masterminds/squirrel, which should make parts much more reusable and, I hope, pave the way to fix this issue.